### PR TITLE
add company name to app.yaml

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -33,6 +33,9 @@ owners:
 - name: Jared Watts
   email: jared@upbound.io
 
+# Human readable company name
+company: Crossplane
+
 # Keywords that describe this application and help search indexing
 keywords:
 - "microsoft"


### PR DESCRIPTION
### Description of your changes

This PR populates the `company` field with a value in the stack's app.yaml.  Note that I am using `Crossplane` currently instead of the company that owns/runs the cloud that this stack is for.  That is because while doing research recently on icons and trademarks, we noticed very specific language around not implying any explicit endorsement or approval of the project/product from the cloud provider.  Therefore, I'd like to keep the company name as "Crossplane" for now and when they take ownership of these stacks then we can change that field.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml