### PR TITLE
    Move manifests target to `kubebuilder.mk` in build submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ GO_SUBDIRS += cmd pkg apis
 # ====================================================================================
 # Setup Kubebuilder
 
+CRD_DIR=config/crd
+API_DIR=./apis/...
+
 -include build/makelib/kubebuilder.mk
 
 # ====================================================================================
@@ -50,7 +53,6 @@ GO_SUBDIRS += cmd pkg apis
 STACK_PACKAGE=stack-package
 export STACK_PACKAGE
 STACK_PACKAGE_REGISTRY=$(STACK_PACKAGE)/.registry
-CRD_DIR=config/crd
 STACK_PACKAGE_REGISTRY_SOURCE=config/stack/manifests
 
 DOCKER_REGISTRY = crossplane
@@ -71,14 +73,6 @@ fallthrough: submodules
 	@echo Initial setup complete. Running make again . . .
 	@make
 
-go.test.unit: $(KUBEBUILDER)
-
-# Generate manifests e.g. CRD, RBAC etc.
-manifests: vendor
-	@$(INFO) Generating CRD manifests
-	@rm -rf $(CRD_DIR)
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd:trivialVersions=true paths=./apis/... output:dir=$(CRD_DIR)
-	@$(OK) Generating CRD manifests
 
 # Generate a coverage report for cobertura applying exclusions on
 # - generated file
@@ -144,14 +138,13 @@ clean: clean-stack-package
 clean-stack-package:
 	@rm -rf $(STACK_PACKAGE)
 
-.PHONY: manifests cobertura reviewable submodules fallthrough test-integration run clean-stack-package build-stack-package
+.PHONY: cobertura reviewable submodules fallthrough test-integration run clean-stack-package build-stack-package
 
 # ====================================================================================
 # Special Targets
 
 define CROSSPLANE_MAKE_HELP
 Crossplane Targets:
-    manifests             Generate manifests e.g. CRD, RBAC etc.
     cobertura             Generate a coverage report for cobertura applying exclusions on generated files.
     reviewable            Ensure a PR is ready for review.
     submodules            Update the submodules, such as the common build scripts.


### PR DESCRIPTION
Signed-off-by: soorena776 <javad@upbound.io>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml