### PR TITLE
VNet managed controller provider ref bugfix

### DIFF
--- a/apis/storage/v1alpha2/test/account.go
+++ b/apis/storage/v1alpha2/test/account.go
@@ -88,8 +88,8 @@ func (ta *MockAccount) WithSpecClaimRef(ref *corev1.ObjectReference) *MockAccoun
 }
 
 // WithSpecProvider set a provider
-func (ta *MockAccount) WithSpecProvider(ns, name string) *MockAccount {
-	ta.Spec.ProviderReference = &corev1.ObjectReference{Namespace: ns, Name: name}
+func (ta *MockAccount) WithSpecProvider(name string) *MockAccount {
+	ta.Spec.ProviderReference = &corev1.ObjectReference{Name: name}
 	return ta
 }
 

--- a/pkg/controller/cache/redis_test.go
+++ b/pkg/controller/cache/redis_test.go
@@ -151,7 +151,7 @@ func redisResource(rm ...redisResourceModifier) *v1alpha2.Redis {
 		},
 		Spec: v1alpha2.RedisSpec{
 			ResourceSpec: runtimev1alpha1.ResourceSpec{
-				ProviderReference: &corev1.ObjectReference{Namespace: namespace, Name: providerName},
+				ProviderReference: &corev1.ObjectReference{Name: providerName},
 				WriteConnectionSecretToReference: &runtimev1alpha1.SecretReference{
 					Namespace: namespace,
 					Name:      connectionSecretName,
@@ -581,7 +581,7 @@ func TestConnect(t *testing.T) {
 			conn: &providerConnecter{
 				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 					switch key {
-					case client.ObjectKey{Namespace: namespace, Name: providerName}:
+					case client.ObjectKey{Name: providerName}:
 						*obj.(*azurev1alpha2.Provider) = provider
 					case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 						*obj.(*corev1.Secret) = providerSecret
@@ -602,14 +602,14 @@ func TestConnect(t *testing.T) {
 				newClient: func(_ context.Context, _ []byte) (redis.Client, error) { return &fakeredis.MockClient{}, nil },
 			},
 			i:       redisResource(),
-			wantErr: errors.WithStack(errors.Errorf("cannot get provider %s/%s:  \"%s\" not found", namespace, providerName, providerName)),
+			wantErr: errors.WithStack(errors.Errorf("cannot get provider /%s:  \"%s\" not found", providerName, providerName)),
 		},
 		{
 			name: "FailedToGetProviderSecret",
 			conn: &providerConnecter{
 				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 					switch key {
-					case client.ObjectKey{Namespace: namespace, Name: providerName}:
+					case client.ObjectKey{Name: providerName}:
 						*obj.(*azurev1alpha2.Provider) = provider
 					case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 						return kerrors.NewNotFound(schema.GroupResource{}, providerSecretName)
@@ -626,7 +626,7 @@ func TestConnect(t *testing.T) {
 			conn: &providerConnecter{
 				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 					switch key {
-					case client.ObjectKey{Namespace: namespace, Name: providerName}:
+					case client.ObjectKey{Name: providerName}:
 						*obj.(*azurev1alpha2.Provider) = provider
 					case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 						*obj.(*corev1.Secret) = providerSecret

--- a/pkg/controller/database/mysqlservervirtualnetworkrule/managed_test.go
+++ b/pkg/controller/database/mysqlservervirtualnetworkrule/managed_test.go
@@ -109,7 +109,6 @@ func withState(s string) virtualNetworkRuleModifier {
 func virtualNetworkRule(sm ...virtualNetworkRuleModifier) *v1alpha2.MysqlServerVirtualNetworkRule {
 	r := &v1alpha2.MysqlServerVirtualNetworkRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  namespace,
 			Name:       name,
 			UID:        uid,
 			Finalizers: []string{},
@@ -443,7 +442,7 @@ func TestConnect(t *testing.T) {
 				client: &test.MockClient{
 					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 						switch key {
-						case client.ObjectKey{Namespace: namespace, Name: providerName}:
+						case client.ObjectKey{Name: providerName}:
 							*obj.(*azurev1alpha2.Provider) = provider
 						case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 							*obj.(*corev1.Secret) = providerSecret

--- a/pkg/controller/database/postgresqlservervirtualnetworkrule/managed_test.go
+++ b/pkg/controller/database/postgresqlservervirtualnetworkrule/managed_test.go
@@ -62,7 +62,7 @@ var (
 	errorBoom = errors.New("boom")
 
 	provider = azurev1alpha2.Provider{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: providerName},
+		ObjectMeta: metav1.ObjectMeta{Name: providerName},
 		Spec: azurev1alpha2.ProviderSpec{
 			Secret: runtimev1alpha1.SecretKeySelector{
 				SecretReference: runtimev1alpha1.SecretReference{
@@ -109,14 +109,13 @@ func withState(s string) virtualNetworkRuleModifier {
 func virtualNetworkRule(sm ...virtualNetworkRuleModifier) *v1alpha2.PostgresqlServerVirtualNetworkRule {
 	r := &v1alpha2.PostgresqlServerVirtualNetworkRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  namespace,
 			Name:       name,
 			UID:        uid,
 			Finalizers: []string{},
 		},
 		Spec: v1alpha2.VirtualNetworkRuleSpec{
 			ResourceSpec: runtimev1alpha1.ResourceSpec{
-				ProviderReference: &corev1.ObjectReference{Namespace: namespace, Name: providerName},
+				ProviderReference: &corev1.ObjectReference{Name: providerName},
 			},
 			Name:              name,
 			ServerName:        serverName,
@@ -443,7 +442,7 @@ func TestConnect(t *testing.T) {
 				client: &test.MockClient{
 					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 						switch key {
-						case client.ObjectKey{Namespace: namespace, Name: providerName}:
+						case client.ObjectKey{Name: providerName}:
 							*obj.(*azurev1alpha2.Provider) = provider
 						case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 							*obj.(*corev1.Secret) = providerSecret

--- a/pkg/controller/network/subnet/managed_test.go
+++ b/pkg/controller/network/subnet/managed_test.go
@@ -62,7 +62,7 @@ var (
 	errorBoom = errors.New("boom")
 
 	provider = azurev1alpha2.Provider{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: providerName},
+		ObjectMeta: metav1.ObjectMeta{Name: providerName},
 		Spec: azurev1alpha2.ProviderSpec{
 			Secret: runtimev1alpha1.SecretKeySelector{
 				SecretReference: runtimev1alpha1.SecretReference{
@@ -101,7 +101,6 @@ func withState(s string) subnetModifier {
 func subnet(sm ...subnetModifier) *v1alpha2.Subnet {
 	r := &v1alpha2.Subnet{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  namespace,
 			Name:       name,
 			UID:        uid,
 			Finalizers: []string{},
@@ -429,7 +428,7 @@ func TestConnect(t *testing.T) {
 				client: &test.MockClient{
 					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 						switch key {
-						case client.ObjectKey{Namespace: namespace, Name: providerName}:
+						case client.ObjectKey{Name: providerName}:
 							*obj.(*azurev1alpha2.Provider) = provider
 						case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 							*obj.(*corev1.Secret) = providerSecret

--- a/pkg/controller/network/virtualnetwork/managed.go
+++ b/pkg/controller/network/virtualnetwork/managed.go
@@ -86,7 +86,7 @@ func (c *connecter) Connect(ctx context.Context, mg resource.Managed) (resource.
 	}
 
 	s := &corev1.Secret{}
-	n = types.NamespacedName{Namespace: p.GetNamespace(), Name: p.Spec.Secret.Name}
+	n = types.NamespacedName{Namespace: p.Spec.Secret.Namespace, Name: p.Spec.Secret.Name}
 	if err := c.client.Get(ctx, n, s); err != nil {
 		return nil, errors.Wrapf(err, "cannot get provider secret %s", n)
 	}

--- a/pkg/controller/network/virtualnetwork/managed_test.go
+++ b/pkg/controller/network/virtualnetwork/managed_test.go
@@ -63,7 +63,7 @@ var (
 	tags      = map[string]string{"one": "test", "two": "test"}
 
 	provider = azurev1alpha2.Provider{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: providerName},
+		ObjectMeta: metav1.ObjectMeta{Name: providerName},
 		Spec: azurev1alpha2.ProviderSpec{
 			Secret: runtimev1alpha1.SecretKeySelector{
 				SecretReference: runtimev1alpha1.SecretReference{
@@ -102,7 +102,6 @@ func withState(s string) virtualNetworkModifier {
 func virtualNetwork(vm ...virtualNetworkModifier) *v1alpha2.VirtualNetwork {
 	r := &v1alpha2.VirtualNetwork{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  namespace,
 			Name:       name,
 			UID:        uid,
 			Finalizers: []string{},
@@ -465,7 +464,7 @@ func TestConnect(t *testing.T) {
 				client: &test.MockClient{
 					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 						switch key {
-						case client.ObjectKey{Namespace: namespace, Name: providerName}:
+						case client.ObjectKey{Name: providerName}:
 							*obj.(*azurev1alpha2.Provider) = provider
 						case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 							*obj.(*corev1.Secret) = providerSecret

--- a/pkg/controller/resourcegroup/resourcegroup_test.go
+++ b/pkg/controller/resourcegroup/resourcegroup_test.go
@@ -60,7 +60,7 @@ var (
 	errorBoom = errors.New("boom")
 
 	provider = azurev1alpha2.Provider{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: providerName},
+		ObjectMeta: metav1.ObjectMeta{Name: providerName},
 		Spec: azurev1alpha2.ProviderSpec{
 			Secret: runtimev1alpha1.SecretKeySelector{
 				SecretReference: runtimev1alpha1.SecretReference{
@@ -111,7 +111,6 @@ func withDeletionTimestamp(t time.Time) resourceModifier {
 func resource(rm ...resourceModifier) *azurev1alpha2.ResourceGroup {
 	r := &azurev1alpha2.ResourceGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  namespace,
 			Name:       name,
 			UID:        uid,
 			Finalizers: []string{},
@@ -120,7 +119,7 @@ func resource(rm ...resourceModifier) *azurev1alpha2.ResourceGroup {
 			Name:     name,
 			Location: location,
 			ResourceSpec: runtimev1alpha1.ResourceSpec{
-				ProviderReference: &corev1.ObjectReference{Namespace: namespace, Name: providerName},
+				ProviderReference: &corev1.ObjectReference{Name: providerName},
 			},
 		},
 		Status: azurev1alpha2.ResourceGroupStatus{},
@@ -383,7 +382,7 @@ func TestConnect(t *testing.T) {
 			conn: &providerConnecter{
 				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 					switch key {
-					case client.ObjectKey{Namespace: namespace, Name: providerName}:
+					case client.ObjectKey{Name: providerName}:
 						*obj.(*azurev1alpha2.Provider) = provider
 					case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 						*obj.(*corev1.Secret) = providerSecret
@@ -408,14 +407,14 @@ func TestConnect(t *testing.T) {
 				},
 			},
 			i:       resource(),
-			wantErr: errors.WithStack(errors.Errorf("cannot get provider %s/%s:  \"%s\" not found", namespace, providerName, providerName)),
+			wantErr: errors.WithStack(errors.Errorf("cannot get provider /%s:  \"%s\" not found", providerName, providerName)),
 		},
 		{
 			name: "FailedToGetProviderSecret",
 			conn: &providerConnecter{
 				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 					switch key {
-					case client.ObjectKey{Namespace: namespace, Name: providerName}:
+					case client.ObjectKey{Name: providerName}:
 						*obj.(*azurev1alpha2.Provider) = provider
 					case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 						return kerrors.NewNotFound(schema.GroupResource{}, providerSecretName)
@@ -434,7 +433,7 @@ func TestConnect(t *testing.T) {
 			conn: &providerConnecter{
 				kube: &test.MockClient{MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
 					switch key {
-					case client.ObjectKey{Namespace: namespace, Name: providerName}:
+					case client.ObjectKey{Name: providerName}:
 						*obj.(*azurev1alpha2.Provider) = provider
 					case client.ObjectKey{Namespace: namespace, Name: providerSecretName}:
 						*obj.(*corev1.Secret) = providerSecret

--- a/pkg/controller/storage/account/account_test.go
+++ b/pkg/controller/storage/account/account_test.go
@@ -185,11 +185,10 @@ type provider struct {
 	*azurev1alpha2.Provider
 }
 
-func newProvider(ns, name string) *provider {
+func newProvider(name string) *provider {
 	return &provider{Provider: &azurev1alpha2.Provider{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
+			Name: name,
 		},
 	}}
 }
@@ -357,35 +356,35 @@ func Test_accountHandleMaker_newHandler(t *testing.T) {
 		{
 			name: "ErrProviderIsNotFound",
 			kube: fake.NewFakeClient(),
-			acct: v1alpha2test.NewMockAccount(bucketName).WithSpecProvider(ns, providerName).Account,
+			acct: v1alpha2test.NewMockAccount(bucketName).WithSpecProvider(providerName).Account,
 			wantErr: errors.Wrapf(
 				kerrors.NewNotFound(schema.GroupResource{Group: azurev1alpha2.Group, Resource: "providers"}, providerName),
-				"cannot get provider %s/%s", ns, providerName,
+				"cannot get provider /%s", providerName,
 			),
 		},
 		{
 			name: "ProviderSecretIsNotFound",
-			kube: fake.NewFakeClient(newProvider(ns, providerName).
+			kube: fake.NewFakeClient(newProvider(providerName).
 				withSecret(ns, secretName, secretKey).Provider),
-			acct: v1alpha2test.NewMockAccount(bucketName).WithSpecProvider(ns, providerName).Account,
+			acct: v1alpha2test.NewMockAccount(bucketName).WithSpecProvider(providerName).Account,
 			wantErr: errors.WithStack(
 				errors.Errorf("cannot get provider's secret %s/%s: secrets \"%s\" not found", ns, secretName, secretName)),
 		},
 		{
 			name: "InvalidCredentials",
-			kube: fake.NewFakeClient(newProvider(ns, providerName).
+			kube: fake.NewFakeClient(newProvider(providerName).
 				withSecret(ns, secretName, secretKey).Provider,
 				newSecret(ns, secretName).Secret),
-			acct: v1alpha2test.NewMockAccount(bucketName).WithSpecProvider(ns, providerName).Account,
+			acct: v1alpha2test.NewMockAccount(bucketName).WithSpecProvider(providerName).Account,
 			wantErr: errors.WithStack(
 				errors.Errorf("cannot create storageClient from json: cannot unmarshal Azure client secret data: unexpected end of JSON input")),
 		},
 		{
 			name: "KubeCreated",
-			kube: fake.NewFakeClient(newProvider(ns, providerName).
+			kube: fake.NewFakeClient(newProvider(providerName).
 				withSecret(ns, secretName, secretKey).Provider,
 				newSecret(ns, secretName).withKeyData(secretKey, secretData).Secret),
-			acct: v1alpha2test.NewMockAccount(bucketName).WithSpecProvider(ns, providerName).Account,
+			acct: v1alpha2test.NewMockAccount(bucketName).WithSpecProvider(providerName).Account,
 			want: newAccountSyncDeleter(&azurestorage.AccountHandle{}, nil, nil),
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Thanks to @turkenh who discovered this bug!

The main fix here is that the virtual network managed controller was not getting the provider secret ref namespace correctly (see first commit). Second update is changing all managed controller tests to not assume that provider has namespace / managed resource has namespace. I will check other stacks to see if these updates are needed.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-azure/blob/master/config/stack/manifests/app.yaml