### PR TITLE
Go 1.13 / k8s Target / controller-runtime bump

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,6 +133,11 @@ issues:
         - gosec
         - scopelint
         - unparam
+    
+    # Exclude gocyclo on generated files
+    - path: zz_generated\.deepcopy\.go
+      linters:
+        - gocyclo
 
     # Ease some gocritic warnings on test files.
     - path: _test\.go

--- a/apis/cache/v1beta1/register.go
+++ b/apis/cache/v1beta1/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/compute/v1alpha3/register.go
+++ b/apis/compute/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/database/v1alpha3/register.go
+++ b/apis/database/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/database/v1beta1/register.go
+++ b/apis/database/v1beta1/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/network/v1alpha3/register.go
+++ b/apis/network/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/storage/v1alpha3/register.go
+++ b/apis/storage/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/v1alpha3/register.go
+++ b/apis/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/cmd/stack/main.go
+++ b/cmd/stack/main.go
@@ -23,9 +23,10 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/crossplaneio/crossplane-runtime/pkg/logging"
 	"github.com/crossplaneio/crossplane/apis"
@@ -51,7 +52,7 @@ func main() {
 	)
 	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	zl := runtimelog.ZapLogger(*debug)
+	zl := zap.Logger(*debug)
 	logging.SetLogger(zl)
 	if *debug {
 		// The controller-runtime runs with a no-op logger by default. It is

--- a/config/crd/azure.crossplane.io_resourcegroups.yaml
+++ b/config/crd/azure.crossplane.io_resourcegroups.yaml
@@ -209,7 +209,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/cache.azure.crossplane.io_redis.yaml
+++ b/config/crd/cache.azure.crossplane.io_redis.yaml
@@ -359,7 +359,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/compute.azure.crossplane.io_aksclusters.yaml
+++ b/config/crd/compute.azure.crossplane.io_aksclusters.yaml
@@ -308,7 +308,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/database.azure.crossplane.io_mysqlservers.yaml
+++ b/config/crd/database.azure.crossplane.io_mysqlservers.yaml
@@ -371,7 +371,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/database.azure.crossplane.io_mysqlservervirtualnetworkrules.yaml
+++ b/config/crd/database.azure.crossplane.io_mysqlservervirtualnetworkrules.yaml
@@ -267,7 +267,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/database.azure.crossplane.io_postgresqlservers.yaml
+++ b/config/crd/database.azure.crossplane.io_postgresqlservers.yaml
@@ -371,7 +371,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/database.azure.crossplane.io_postgresqlservervirtualnetworkrules.yaml
+++ b/config/crd/database.azure.crossplane.io_postgresqlservervirtualnetworkrules.yaml
@@ -267,7 +267,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/network.azure.crossplane.io_subnets.yaml
+++ b/config/crd/network.azure.crossplane.io_subnets.yaml
@@ -278,7 +278,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/network.azure.crossplane.io_virtualnetworks.yaml
+++ b/config/crd/network.azure.crossplane.io_virtualnetworks.yaml
@@ -274,7 +274,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/storage.azure.crossplane.io_accounts.yaml
+++ b/config/crd/storage.azure.crossplane.io_accounts.yaml
@@ -479,7 +479,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/storage.azure.crossplane.io_containers.yaml
+++ b/config/crd/storage.azure.crossplane.io_containers.yaml
@@ -200,7 +200,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplaneio/stack-azure
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.2 // indirect
@@ -12,8 +12,8 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.2.0
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
-	github.com/crossplaneio/crossplane v0.6.0-rc.0.20191226165033-a452562456e0
-	github.com/crossplaneio/crossplane-runtime v0.3.0
+	github.com/crossplaneio/crossplane v0.6.0-rc.0.20200115221822-c06433fc39c6
+	github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115232149-cd8c52b483c3
 	github.com/crossplaneio/crossplane-tools v0.0.0-20191220202319-9033bd8a02ce
 	github.com/google/go-cmp v0.3.1
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -77,10 +77,11 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
-github.com/crossplaneio/crossplane v0.6.0-rc.0.20191226165033-a452562456e0 h1:Sp1jDkEaEuJyXQzmU+fT4GVdlynzblXslHE/+DbJ3jg=
-github.com/crossplaneio/crossplane v0.6.0-rc.0.20191226165033-a452562456e0/go.mod h1:lW/xhJfNx5QQve/9xH2JszMqtSfVlEQBtKE0u96qlCI=
-github.com/crossplaneio/crossplane-runtime v0.3.0 h1:d3937o6XhVUcm/bqgUPUjTo/OjVlAjh1c7rx4VPJoV8=
-github.com/crossplaneio/crossplane-runtime v0.3.0/go.mod h1:aVLQmXiPeb/jhGGQFIxx4Rc1CFC6xq2BA6A3neLZIHA=
+github.com/crossplaneio/crossplane v0.6.0-rc.0.20200115221822-c06433fc39c6 h1:GWyXwoVIMItJUqhIxjx0X8hcnkYtzSnDWbbmoUsjWN4=
+github.com/crossplaneio/crossplane v0.6.0-rc.0.20200115221822-c06433fc39c6/go.mod h1:8V5faxSOvBejN2Rlaw6g7ZwyqxkMkeD72TpNjOKmkks=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200114203641-5ece4af54b32/go.mod h1:aVLQmXiPeb/jhGGQFIxx4Rc1CFC6xq2BA6A3neLZIHA=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115232149-cd8c52b483c3 h1:S7eTG5kLDUOp1ddUkO7wajPH8HEun1LZRyJLuKu/PhU=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115232149-cd8c52b483c3/go.mod h1:UTemZ8u+bvHkQMHpdsZ2z/dTHC7tRkXc2K6Z9N26KQI=
 github.com/crossplaneio/crossplane-tools v0.0.0-20191023215726-61fa1eff2a2e h1:8Z29akSDYcbywc/brATpfeE425jBTMZdZQuD9eV6cCk=
 github.com/crossplaneio/crossplane-tools v0.0.0-20191023215726-61fa1eff2a2e/go.mod h1:fzQeWDvZvzaC4N8vPjTubQocGnwzQ4cuZM6949+T43U=
 github.com/crossplaneio/crossplane-tools v0.0.0-20191220202319-9033bd8a02ce h1:V7cUPRBxbJr0siRHn459gb6hfMXaEA+pGm0Yt5aXdhQ=

--- a/pkg/clients/storage/container.go
+++ b/pkg/clients/storage/container.go
@@ -109,5 +109,5 @@ func IsNotFoundError(err error) bool {
 		return false
 	}
 
-	return storageErr.Response().StatusCode == http.StatusNotFound
+	return storageErr.Response().StatusCode == http.StatusNotFound // nolint: bodyclose
 }

--- a/pkg/controller/azure.go
+++ b/pkg/controller/azure.go
@@ -50,6 +50,7 @@ func (c *Controllers) SetupWithManager(mgr ctrl.Manager) error {
 		&compute.AKSClusterClaimSchedulingController{},
 		&compute.AKSClusterClaimDefaultingController{},
 		&compute.AKSClusterClaimController{},
+		&compute.AKSClusterTargetController{},
 		&compute.AKSClusterController{Reconciler: aksReconciler},
 		&mysqlserver.ClaimSchedulingController{},
 		&mysqlserver.ClaimDefaultingController{},

--- a/pkg/controller/cache/claim.go
+++ b/pkg/controller/cache/claim.go
@@ -26,6 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	cachev1alpha1 "github.com/crossplaneio/crossplane/apis/cache/v1alpha1"
 
@@ -53,7 +56,7 @@ func (c *RedisClaimSchedulingController) SetupWithManager(mgr ctrl.Manager) erro
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
 			resource.ClassKind(v1beta1.RedisClassGroupVersionKind),
 		))
@@ -80,7 +83,7 @@ func (c *RedisClaimDefaultingController) SetupWithManager(mgr ctrl.Manager) erro
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
 			resource.ClassKind(v1beta1.RedisClassGroupVersionKind),
 		))
@@ -97,15 +100,15 @@ func (c *RedisClaimController) SetupWithManager(mgr ctrl.Manager) error {
 		v1beta1.RedisKind,
 		v1beta1.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
 		resource.ClassKind(v1beta1.RedisClassGroupVersionKind),
 		resource.ManagedKind(v1beta1.RedisGroupVersionKind),
-		resource.WithBinder(resource.NewAPIBinder(mgr.GetClient(), mgr.GetScheme())),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureRedis),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithBinder(claimbinding.NewAPIBinder(mgr.GetClient(), mgr.GetScheme())),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureRedis),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/cache/claim_test.go
+++ b/pkg/controller/cache/claim_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	cachev1alpha1 "github.com/crossplaneio/crossplane/apis/cache/v1alpha1"
@@ -39,7 +40,7 @@ const (
 	claimVersion40 = "4.0"
 )
 
-var _ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureRedis)
+var _ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureRedis)
 
 func TestConfigureRedis(t *testing.T) {
 	type args struct {

--- a/pkg/controller/cache/redis_test.go
+++ b/pkg/controller/cache/redis_test.go
@@ -34,7 +34,7 @@ import (
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
-	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 
 	"github.com/crossplaneio/stack-azure/apis/cache/v1beta1"
@@ -162,8 +162,8 @@ func instance(rm ...redisResourceModifier) *v1beta1.Redis {
 	return r
 }
 
-var _ resource.ExternalClient = &external{}
-var _ resource.ExternalConnecter = &connector{}
+var _ managed.ExternalClient = &external{}
+var _ managed.ExternalConnecter = &connector{}
 
 func TestConnect(t *testing.T) {
 	type args struct {
@@ -286,7 +286,7 @@ func TestObserve(t *testing.T) {
 	}
 	type want struct {
 		cr  *v1beta1.Redis
-		o   resource.ExternalObservation
+		o   managed.ExternalObservation
 		err error
 	}
 
@@ -325,10 +325,10 @@ func TestObserve(t *testing.T) {
 					withConditions(runtimev1alpha1.Available()),
 					withBindingPhase(runtimev1alpha1.BindingPhaseUnbound),
 				),
-				o: resource.ExternalObservation{
+				o: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: false,
-					ConnectionDetails: resource.ConnectionDetails{
+					ConnectionDetails: managed.ConnectionDetails{
 						runtimev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(hostName),
 						runtimev1alpha1.ResourceCredentialsSecretPortKey:     []byte(strconv.Itoa(port)),
 						runtimev1alpha1.ResourceCredentialsSecretPasswordKey: []byte(primaryKey),
@@ -409,7 +409,7 @@ func TestObserve(t *testing.T) {
 					withProvisioningState(redisclient.ProvisioningStateCreating),
 					withConditions(runtimev1alpha1.Creating()),
 				),
-				o: resource.ExternalObservation{
+				o: managed.ExternalObservation{
 					ResourceUpToDate: false,
 					ResourceExists:   true,
 				},
@@ -435,7 +435,7 @@ func TestObserve(t *testing.T) {
 					withProvisioningState(redisclient.ProvisioningStateDeleting),
 					withConditions(runtimev1alpha1.Deleting()),
 				),
-				o: resource.ExternalObservation{
+				o: managed.ExternalObservation{
 					ResourceUpToDate: false,
 					ResourceExists:   true,
 				},
@@ -461,7 +461,7 @@ func TestObserve(t *testing.T) {
 					withProvisioningState(redisclient.ProvisioningStateFailed),
 					withConditions(runtimev1alpha1.Unavailable()),
 				),
-				o: resource.ExternalObservation{
+				o: managed.ExternalObservation{
 					ResourceUpToDate: false,
 					ResourceExists:   true,
 				},
@@ -496,7 +496,7 @@ func TestCreate(t *testing.T) {
 	}
 	type want struct {
 		cr  *v1beta1.Redis
-		o   resource.ExternalCreation
+		o   managed.ExternalCreation
 		err error
 	}
 	cases := map[string]struct {
@@ -561,7 +561,7 @@ func TestUpdate(t *testing.T) {
 	}
 	type want struct {
 		cr  *v1beta1.Redis
-		o   resource.ExternalUpdate
+		o   managed.ExternalUpdate
 		err error
 	}
 	cases := map[string]struct {

--- a/pkg/controller/compute/claim.go
+++ b/pkg/controller/compute/claim.go
@@ -27,6 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	computev1alpha1 "github.com/crossplaneio/crossplane/apis/compute/v1alpha1"
 
@@ -54,7 +57,7 @@ func (c *AKSClusterClaimSchedulingController) SetupWithManager(mgr ctrl.Manager)
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
 			resource.ClassKind(v1alpha3.AKSClusterClassGroupVersionKind),
 		))
@@ -81,7 +84,7 @@ func (c *AKSClusterClaimDefaultingController) SetupWithManager(mgr ctrl.Manager)
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
 			resource.ClassKind(v1alpha3.AKSClusterClassGroupVersionKind),
 		))
@@ -99,15 +102,15 @@ func (c *AKSClusterClaimController) SetupWithManager(mgr ctrl.Manager) error {
 		v1alpha3.AKSClusterKind,
 		v1alpha3.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
 		resource.ClassKind(v1alpha3.AKSClusterClassGroupVersionKind),
 		resource.ManagedKind(v1alpha3.AKSClusterGroupVersionKind),
-		resource.WithBinder(resource.NewAPIBinder(mgr.GetClient(), mgr.GetScheme())),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureAKSCluster),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithBinder(claimbinding.NewAPIBinder(mgr.GetClient(), mgr.GetScheme())),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureAKSCluster),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/compute/claim_test.go
+++ b/pkg/controller/compute/claim_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	computev1alpha1 "github.com/crossplaneio/crossplane/apis/compute/v1alpha1"
@@ -34,7 +35,7 @@ import (
 	"github.com/crossplaneio/stack-azure/apis/compute/v1alpha3"
 )
 
-var _ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureAKSCluster)
+var _ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureAKSCluster)
 
 func TestConfigureAKSCluster(t *testing.T) {
 	type args struct {

--- a/pkg/controller/compute/target.go
+++ b/pkg/controller/compute/target.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compute
+
+import (
+	"fmt"
+	"strings"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/target"
+	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane/apis/workload/v1alpha1"
+
+	"github.com/crossplaneio/stack-azure/apis/compute/v1alpha3"
+)
+
+// AKSClusterTargetController is responsible for adding the AKSCluster target
+// controller and its corresponding reconciler to the manager with any runtime configuration.
+type AKSClusterTargetController struct{}
+
+// SetupWithManager adds a controller that propagates AKSCluster connection
+// secrets to the connection secrets of their targets.
+func (c *AKSClusterTargetController) SetupWithManager(mgr ctrl.Manager) error {
+	p := resource.NewPredicates(resource.HasManagedResourceReferenceKind(resource.ManagedKind(v1alpha3.AKSClusterGroupVersionKind)))
+
+	r := target.NewReconciler(mgr,
+		resource.TargetKind(v1alpha1.KubernetesTargetGroupVersionKind),
+		resource.ManagedKind(v1alpha3.AKSClusterGroupVersionKind))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(strings.ToLower(fmt.Sprintf("kubernetestarget.%s.%s", v1alpha3.AKSClusterKind, v1alpha3.Group))).
+		For(&v1alpha1.KubernetesTarget{}).
+		WithEventFilter(p).
+		Complete(r)
+}

--- a/pkg/controller/database/mysqlserver/claim.go
+++ b/pkg/controller/database/mysqlserver/claim.go
@@ -26,6 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	databasev1alpha1 "github.com/crossplaneio/crossplane/apis/database/v1alpha1"
 
@@ -53,7 +56,7 @@ func (c *ClaimSchedulingController) SetupWithManager(mgr ctrl.Manager) error {
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
 			resource.ClassKind(v1beta1.SQLServerClassGroupVersionKind),
 		))
@@ -80,7 +83,7 @@ func (c *ClaimDefaultingController) SetupWithManager(mgr ctrl.Manager) error {
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
 			resource.ClassKind(v1beta1.SQLServerClassGroupVersionKind),
 		))
@@ -97,14 +100,14 @@ func (c *ClaimController) SetupWithManager(mgr ctrl.Manager) error {
 		v1beta1.MySQLServerKind,
 		v1beta1.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
 		resource.ClassKind(v1beta1.SQLServerClassGroupVersionKind),
 		resource.ManagedKind(v1beta1.MySQLServerGroupVersionKind),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureMySQLServer),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureMySQLServer),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/database/mysqlserver/claim_test.go
+++ b/pkg/controller/database/mysqlserver/claim_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	databasev1alpha1 "github.com/crossplaneio/crossplane/apis/database/v1alpha1"
@@ -33,7 +34,7 @@ import (
 	"github.com/crossplaneio/stack-azure/apis/database/v1beta1"
 )
 
-var _ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureMySQLServer)
+var _ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureMySQLServer)
 
 func TestConfigureMySQLServer(t *testing.T) {
 	type args struct {

--- a/pkg/controller/database/mysqlserver/managed_test.go
+++ b/pkg/controller/database/mysqlserver/managed_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/crossplaneio/stack-azure/pkg/clients/database"
 
 	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/mysql/mgmt/mysql"
 	"github.com/Azure/go-autorest/autorest"
@@ -42,8 +43,8 @@ import (
 )
 
 var (
-	_ resource.ExternalClient    = &external{}
-	_ resource.ExternalConnecter = &connecter{}
+	_ managed.ExternalClient    = &external{}
+	_ managed.ExternalConnecter = &connecter{}
 )
 
 type MockMySQLServerAPI struct {
@@ -117,7 +118,7 @@ func TestConnect(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		ec   resource.ExternalConnecter
+		ec   managed.ExternalConnecter
 		args args
 		want error
 	}{
@@ -200,12 +201,12 @@ func TestObserve(t *testing.T) {
 		mg  resource.Managed
 	}
 	type want struct {
-		eo  resource.ExternalObservation
+		eo  managed.ExternalObservation
 		err error
 	}
 
 	cases := map[string]struct {
-		e    resource.ExternalClient
+		e    managed.ExternalClient
 		args args
 		want want
 	}{
@@ -269,7 +270,7 @@ func TestObserve(t *testing.T) {
 				mg:  mysqlserver(),
 			},
 			want: want{
-				eo: resource.ExternalObservation{
+				eo: managed.ExternalObservation{
 					ResourceExists: true,
 				},
 			},
@@ -290,7 +291,7 @@ func TestObserve(t *testing.T) {
 				mg:  mysqlserver(),
 			},
 			want: want{
-				eo: resource.ExternalObservation{
+				eo: managed.ExternalObservation{
 					ResourceExists: false,
 				},
 			},
@@ -325,10 +326,10 @@ func TestObserve(t *testing.T) {
 				),
 			},
 			want: want{
-				eo: resource.ExternalObservation{
+				eo: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
-					ConnectionDetails: resource.ConnectionDetails{
+					ConnectionDetails: managed.ConnectionDetails{
 						runtimev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(endpoint),
 						runtimev1alpha1.ResourceCredentialsSecretUserKey:     []byte(fmt.Sprintf("%s@%s", admin, name)),
 					},
@@ -360,12 +361,12 @@ func TestCreate(t *testing.T) {
 		mg  resource.Managed
 	}
 	type want struct {
-		ec  resource.ExternalCreation
+		ec  managed.ExternalCreation
 		err error
 	}
 
 	cases := map[string]struct {
-		e    resource.ExternalClient
+		e    managed.ExternalClient
 		args args
 		want want
 	}{
@@ -422,8 +423,8 @@ func TestCreate(t *testing.T) {
 				mg:  mysqlserver(),
 			},
 			want: want{
-				ec: resource.ExternalCreation{
-					ConnectionDetails: resource.ConnectionDetails{runtimev1alpha1.ResourceCredentialsSecretPasswordKey: []byte(password)},
+				ec: managed.ExternalCreation{
+					ConnectionDetails: managed.ConnectionDetails{runtimev1alpha1.ResourceCredentialsSecretPasswordKey: []byte(password)},
 				},
 			},
 		},
@@ -452,7 +453,7 @@ func TestDelete(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		e    resource.ExternalClient
+		e    managed.ExternalClient
 		args args
 		want error
 	}{

--- a/pkg/controller/database/mysqlservervirtualnetworkrule/managed_test.go
+++ b/pkg/controller/database/mysqlservervirtualnetworkrule/managed_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 
@@ -86,7 +87,7 @@ var (
 
 type testCase struct {
 	name    string
-	e       resource.ExternalClient
+	e       managed.ExternalClient
 	r       resource.Managed
 	want    resource.Managed
 	wantErr error
@@ -140,8 +141,8 @@ func virtualNetworkRule(sm ...virtualNetworkRuleModifier) *v1alpha3.MySQLServerV
 }
 
 // Test that our Reconciler implementation satisfies the Reconciler interface.
-var _ resource.ExternalClient = &external{}
-var _ resource.ExternalConnecter = &connecter{}
+var _ managed.ExternalClient = &external{}
+var _ managed.ExternalConnecter = &connecter{}
 
 func TestCreate(t *testing.T) {
 	cases := []testCase{
@@ -430,7 +431,7 @@ func TestConnect(t *testing.T) {
 		name    string
 		conn    *connecter
 		i       resource.Managed
-		want    resource.ExternalClient
+		want    managed.ExternalClient
 		wantErr error
 	}{
 		{

--- a/pkg/controller/database/postgresqlserver/claim.go
+++ b/pkg/controller/database/postgresqlserver/claim.go
@@ -26,6 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	databasev1alpha1 "github.com/crossplaneio/crossplane/apis/database/v1alpha1"
 
@@ -53,7 +56,7 @@ func (c *ClaimSchedulingController) SetupWithManager(mgr ctrl.Manager) error {
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
 			resource.ClassKind(v1beta1.SQLServerClassGroupVersionKind),
 		))
@@ -80,7 +83,7 @@ func (c *ClaimDefaultingController) SetupWithManager(mgr ctrl.Manager) error {
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
 			resource.ClassKind(v1beta1.SQLServerClassGroupVersionKind),
 		))
@@ -97,14 +100,14 @@ func (c *ClaimController) SetupWithManager(mgr ctrl.Manager) error {
 		v1beta1.PostgreSQLServerKind,
 		v1beta1.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
 		resource.ClassKind(v1beta1.SQLServerClassGroupVersionKind),
 		resource.ManagedKind(v1beta1.PostgreSQLServerGroupVersionKind),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigurePostgreSQLServer),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigurePostgreSQLServer),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/database/postgresqlserver/claim_test.go
+++ b/pkg/controller/database/postgresqlserver/claim_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	databasev1alpha1 "github.com/crossplaneio/crossplane/apis/database/v1alpha1"
@@ -33,7 +34,7 @@ import (
 	"github.com/crossplaneio/stack-azure/apis/database/v1beta1"
 )
 
-var _ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigurePostgreSQLServer)
+var _ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigurePostgreSQLServer)
 
 func TestConfigurePostgreSQLServer(t *testing.T) {
 	type args struct {

--- a/pkg/controller/database/postgresqlserver/managed_test.go
+++ b/pkg/controller/database/postgresqlserver/managed_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/crossplaneio/stack-azure/pkg/clients/database"
 
 	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/postgresql/mgmt/postgresql"
 	"github.com/Azure/go-autorest/autorest"
@@ -42,8 +43,8 @@ import (
 )
 
 var (
-	_ resource.ExternalClient    = &external{}
-	_ resource.ExternalConnecter = &connecter{}
+	_ managed.ExternalClient    = &external{}
+	_ managed.ExternalConnecter = &connecter{}
 )
 
 type MockPostgreSQLServerAPI struct {
@@ -117,7 +118,7 @@ func TestConnect(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		ec   resource.ExternalConnecter
+		ec   managed.ExternalConnecter
 		args args
 		want error
 	}{
@@ -200,12 +201,12 @@ func TestObserve(t *testing.T) {
 		mg  resource.Managed
 	}
 	type want struct {
-		eo  resource.ExternalObservation
+		eo  managed.ExternalObservation
 		err error
 	}
 
 	cases := map[string]struct {
-		e    resource.ExternalClient
+		e    managed.ExternalClient
 		args args
 		want want
 	}{
@@ -269,7 +270,7 @@ func TestObserve(t *testing.T) {
 				mg:  postgresqlserver(),
 			},
 			want: want{
-				eo: resource.ExternalObservation{
+				eo: managed.ExternalObservation{
 					ResourceExists: true,
 				},
 			},
@@ -290,7 +291,7 @@ func TestObserve(t *testing.T) {
 				mg:  postgresqlserver(),
 			},
 			want: want{
-				eo: resource.ExternalObservation{
+				eo: managed.ExternalObservation{
 					ResourceExists: false,
 				},
 			},
@@ -325,10 +326,10 @@ func TestObserve(t *testing.T) {
 				),
 			},
 			want: want{
-				eo: resource.ExternalObservation{
+				eo: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
-					ConnectionDetails: resource.ConnectionDetails{
+					ConnectionDetails: managed.ConnectionDetails{
 						runtimev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(endpoint),
 						runtimev1alpha1.ResourceCredentialsSecretUserKey:     []byte(fmt.Sprintf("%s@%s", admin, name)),
 					},
@@ -360,12 +361,12 @@ func TestCreate(t *testing.T) {
 		mg  resource.Managed
 	}
 	type want struct {
-		ec  resource.ExternalCreation
+		ec  managed.ExternalCreation
 		err error
 	}
 
 	cases := map[string]struct {
-		e    resource.ExternalClient
+		e    managed.ExternalClient
 		args args
 		want want
 	}{
@@ -422,8 +423,8 @@ func TestCreate(t *testing.T) {
 				mg:  postgresqlserver(),
 			},
 			want: want{
-				ec: resource.ExternalCreation{
-					ConnectionDetails: resource.ConnectionDetails{runtimev1alpha1.ResourceCredentialsSecretPasswordKey: []byte(password)},
+				ec: managed.ExternalCreation{
+					ConnectionDetails: managed.ConnectionDetails{runtimev1alpha1.ResourceCredentialsSecretPasswordKey: []byte(password)},
 				},
 			},
 		},
@@ -452,7 +453,7 @@ func TestDelete(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		e    resource.ExternalClient
+		e    managed.ExternalClient
 		args args
 		want error
 	}{

--- a/pkg/controller/database/postgresqlservervirtualnetworkrule/managed_test.go
+++ b/pkg/controller/database/postgresqlservervirtualnetworkrule/managed_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 
@@ -85,7 +86,7 @@ var (
 
 type testCase struct {
 	name    string
-	e       resource.ExternalClient
+	e       managed.ExternalClient
 	r       resource.Managed
 	want    resource.Managed
 	wantErr error
@@ -139,8 +140,8 @@ func virtualNetworkRule(sm ...virtualNetworkRuleModifier) *v1alpha3.PostgreSQLSe
 }
 
 // Test that our Reconciler implementation satisfies the Reconciler interface.
-var _ resource.ExternalClient = &external{}
-var _ resource.ExternalConnecter = &connecter{}
+var _ managed.ExternalClient = &external{}
+var _ managed.ExternalConnecter = &connecter{}
 
 func TestCreate(t *testing.T) {
 	cases := []testCase{
@@ -429,7 +430,7 @@ func TestConnect(t *testing.T) {
 		name    string
 		conn    *connecter
 		i       resource.Managed
-		want    resource.ExternalClient
+		want    managed.ExternalClient
 		wantErr error
 	}{
 		{

--- a/pkg/controller/network/subnet/managed_test.go
+++ b/pkg/controller/network/subnet/managed_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/crossplaneio/stack-azure/pkg/clients/network/fake"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 )
@@ -84,7 +85,7 @@ var (
 
 type testCase struct {
 	name    string
-	e       resource.ExternalClient
+	e       managed.ExternalClient
 	r       resource.Managed
 	want    resource.Managed
 	wantErr error
@@ -129,8 +130,8 @@ func subnet(sm ...subnetModifier) *v1alpha3.Subnet {
 }
 
 // Test that our Reconciler implementation satisfies the Reconciler interface.
-var _ resource.ExternalClient = &external{}
-var _ resource.ExternalConnecter = &connecter{}
+var _ managed.ExternalClient = &external{}
+var _ managed.ExternalConnecter = &connecter{}
 
 func TestCreate(t *testing.T) {
 	cases := []testCase{
@@ -414,7 +415,7 @@ func TestConnect(t *testing.T) {
 		name    string
 		conn    *connecter
 		i       resource.Managed
-		want    resource.ExternalClient
+		want    managed.ExternalClient
 		wantErr error
 	}{
 		{

--- a/pkg/controller/network/virtualnetwork/managed.go
+++ b/pkg/controller/network/virtualnetwork/managed.go
@@ -29,6 +29,7 @@ import (
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplaneio/stack-azure/apis/network/v1alpha3"
@@ -55,10 +56,10 @@ type Controller struct{}
 // Manager with default RBAC. The Manager will set fields on the Controller and
 // start it when the Manager is Started.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
-	r := resource.NewManagedReconciler(mgr,
+	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(v1alpha3.VirtualNetworkGroupVersionKind),
-		resource.WithManagedConnectionPublishers(),
-		resource.WithExternalConnecter(&connecter{client: mgr.GetClient()}))
+		managed.WithConnectionPublishers(),
+		managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}))
 
 	name := strings.ToLower(fmt.Sprintf("%s.%s", v1alpha3.VirtualNetworkKind, v1alpha3.Group))
 
@@ -73,7 +74,7 @@ type connecter struct {
 	newClientFn func(ctx context.Context, credentials []byte) (network.VirtualNetworksClient, error)
 }
 
-func (c *connecter) Connect(ctx context.Context, mg resource.Managed) (resource.ExternalClient, error) {
+func (c *connecter) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
 	g, ok := mg.(*v1alpha3.VirtualNetwork)
 	if !ok {
 		return nil, errors.New(errNotVirtualNetwork)
@@ -100,66 +101,66 @@ func (c *connecter) Connect(ctx context.Context, mg resource.Managed) (resource.
 
 type external struct{ client network.VirtualNetworksClient }
 
-func (e *external) Observe(ctx context.Context, mg resource.Managed) (resource.ExternalObservation, error) {
+func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
 	v, ok := mg.(*v1alpha3.VirtualNetwork)
 	if !ok {
-		return resource.ExternalObservation{}, errors.New(errNotVirtualNetwork)
+		return managed.ExternalObservation{}, errors.New(errNotVirtualNetwork)
 	}
 
 	az, err := e.client.Get(ctx, v.Spec.ResourceGroupName, v.Spec.Name, "")
 	if azureclients.IsNotFound(err) {
-		return resource.ExternalObservation{ResourceExists: false}, nil
+		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
 	if err != nil {
-		return resource.ExternalObservation{}, errors.Wrap(err, errGetVirtualNetwork)
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetVirtualNetwork)
 	}
 
 	network.UpdateVirtualNetworkStatusFromAzure(v, az)
 
 	v.SetConditions(runtimev1alpha1.Available())
 
-	o := resource.ExternalObservation{
+	o := managed.ExternalObservation{
 		ResourceExists:    true,
-		ConnectionDetails: resource.ConnectionDetails{},
+		ConnectionDetails: managed.ConnectionDetails{},
 	}
 
 	return o, nil
 }
 
-func (e *external) Create(ctx context.Context, mg resource.Managed) (resource.ExternalCreation, error) {
+func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
 	v, ok := mg.(*v1alpha3.VirtualNetwork)
 	if !ok {
-		return resource.ExternalCreation{}, errors.New(errNotVirtualNetwork)
+		return managed.ExternalCreation{}, errors.New(errNotVirtualNetwork)
 	}
 
 	v.Status.SetConditions(runtimev1alpha1.Creating())
 
 	vnet := network.NewVirtualNetworkParameters(v)
 	if _, err := e.client.CreateOrUpdate(ctx, v.Spec.ResourceGroupName, v.Spec.Name, vnet); err != nil {
-		return resource.ExternalCreation{}, errors.Wrap(err, errCreateVirtualNetwork)
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreateVirtualNetwork)
 	}
 
-	return resource.ExternalCreation{}, nil
+	return managed.ExternalCreation{}, nil
 }
 
-func (e *external) Update(ctx context.Context, mg resource.Managed) (resource.ExternalUpdate, error) {
+func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
 	v, ok := mg.(*v1alpha3.VirtualNetwork)
 	if !ok {
-		return resource.ExternalUpdate{}, errors.New(errNotVirtualNetwork)
+		return managed.ExternalUpdate{}, errors.New(errNotVirtualNetwork)
 	}
 
 	az, err := e.client.Get(ctx, v.Spec.ResourceGroupName, v.Spec.Name, "")
 	if err != nil {
-		return resource.ExternalUpdate{}, errors.Wrap(err, errGetVirtualNetwork)
+		return managed.ExternalUpdate{}, errors.Wrap(err, errGetVirtualNetwork)
 	}
 
 	if network.VirtualNetworkNeedsUpdate(v, az) {
 		vnet := network.NewVirtualNetworkParameters(v)
 		if _, err := e.client.CreateOrUpdate(ctx, v.Spec.ResourceGroupName, v.Spec.Name, vnet); err != nil {
-			return resource.ExternalUpdate{}, errors.Wrap(err, errUpdateVirtualNetwork)
+			return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateVirtualNetwork)
 		}
 	}
-	return resource.ExternalUpdate{}, nil
+	return managed.ExternalUpdate{}, nil
 }
 
 func (e *external) Delete(ctx context.Context, mg resource.Managed) error {

--- a/pkg/controller/network/virtualnetwork/managed_test.go
+++ b/pkg/controller/network/virtualnetwork/managed_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 
@@ -85,7 +86,7 @@ var (
 
 type testCase struct {
 	name    string
-	e       resource.ExternalClient
+	e       managed.ExternalClient
 	r       resource.Managed
 	want    resource.Managed
 	wantErr error
@@ -135,8 +136,8 @@ func virtualNetwork(vm ...virtualNetworkModifier) *v1alpha3.VirtualNetwork {
 }
 
 // Test that our Reconciler implementation satisfies the Reconciler interface.
-var _ resource.ExternalClient = &external{}
-var _ resource.ExternalConnecter = &connecter{}
+var _ managed.ExternalClient = &external{}
+var _ managed.ExternalConnecter = &connecter{}
 
 func TestCreate(t *testing.T) {
 	cases := []testCase{
@@ -450,7 +451,7 @@ func TestConnect(t *testing.T) {
 		name    string
 		conn    *connecter
 		i       resource.Managed
-		want    resource.ExternalClient
+		want    managed.ExternalClient
 		wantErr error
 	}{
 		{

--- a/pkg/controller/resourcegroup/resourcegroup_test.go
+++ b/pkg/controller/resourcegroup/resourcegroup_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 
 	azurev1alpha3 "github.com/crossplaneio/stack-azure/apis/v1alpha3"
@@ -513,7 +513,7 @@ func TestReconcile(t *testing.T) {
 					},
 					MockUpdate: func(_ context.Context, _ runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
-				ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(struct{ client.Client }{}),
+				ReferenceResolver: managed.NewAPIReferenceResolver(struct{ client.Client }{}),
 			},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
 			want:    reconcile.Result{Requeue: false},
@@ -532,7 +532,7 @@ func TestReconcile(t *testing.T) {
 					},
 					MockUpdate: func(_ context.Context, _ runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
-				ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(struct{ client.Client }{}),
+				ReferenceResolver: managed.NewAPIReferenceResolver(struct{ client.Client }{}),
 			},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
 			want:    reconcile.Result{Requeue: true},
@@ -554,7 +554,7 @@ func TestReconcile(t *testing.T) {
 					MockUpdate: func(_ context.Context, _ runtime.Object, _ ...client.UpdateOption) error { return nil },
 					MockCreate: func(_ context.Context, _ runtime.Object, _ ...client.CreateOption) error { return nil },
 				},
-				ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(struct{ client.Client }{}),
+				ReferenceResolver: managed.NewAPIReferenceResolver(struct{ client.Client }{}),
 			},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
 			want:    reconcile.Result{Requeue: false},
@@ -608,7 +608,7 @@ func TestReconcile(t *testing.T) {
 						return nil
 					},
 				},
-				ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(struct{ client.Client }{}),
+				ReferenceResolver: managed.NewAPIReferenceResolver(struct{ client.Client }{}),
 			},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
 			want:    reconcile.Result{Requeue: true},

--- a/pkg/controller/storage/account/account_test.go
+++ b/pkg/controller/storage/account/account_test.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 
 	"github.com/crossplaneio/stack-azure/apis/storage/v1alpha3"
@@ -309,9 +309,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
-				Client:                   tt.fields.client,
-				syncdeleterMaker:         tt.fields.maker,
-				ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(struct{ client.Client }{}),
+				Client:            tt.fields.client,
+				syncdeleterMaker:  tt.fields.maker,
+				ReferenceResolver: managed.NewAPIReferenceResolver(struct{ client.Client }{}),
 			}
 			got, err := r.Reconcile(req)
 			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {

--- a/pkg/controller/storage/account/claim.go
+++ b/pkg/controller/storage/account/claim.go
@@ -26,6 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/apis/storage/v1alpha1"
 
@@ -53,7 +56,7 @@ func (c *ClaimSchedulingController) SetupWithManager(mgr ctrl.Manager) error {
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 			resource.ClassKind(v1alpha3.AccountClassGroupVersionKind),
 		))
@@ -80,7 +83,7 @@ func (c *ClaimDefaultingController) SetupWithManager(mgr ctrl.Manager) error {
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 			resource.ClassKind(v1alpha3.AccountClassGroupVersionKind),
 		))
@@ -97,13 +100,13 @@ func (c *ClaimController) SetupWithManager(mgr ctrl.Manager) error {
 		v1alpha3.AccountKind,
 		v1alpha3.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 		resource.ClassKind(v1alpha3.AccountClassGroupVersionKind),
 		resource.ManagedKind(v1alpha3.AccountGroupVersionKind),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureAccount),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureAccount),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/storage/account/claim_test.go
+++ b/pkg/controller/storage/account/claim_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/apis/storage/v1alpha1"
@@ -33,7 +34,7 @@ import (
 	"github.com/crossplaneio/stack-azure/apis/storage/v1alpha3"
 )
 
-var _ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureAccount)
+var _ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureAccount)
 
 func TestConfigureAccount(t *testing.T) {
 	type args struct {

--- a/pkg/controller/storage/container/claim.go
+++ b/pkg/controller/storage/container/claim.go
@@ -29,6 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/apis/storage/v1alpha1"
 
@@ -56,7 +59,7 @@ func (c *ClaimSchedulingController) SetupWithManager(mgr ctrl.Manager) error {
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 			resource.ClassKind(v1alpha3.ContainerClassGroupVersionKind),
 		))
@@ -83,7 +86,7 @@ func (c *ClaimDefaultingController) SetupWithManager(mgr ctrl.Manager) error {
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 			resource.ClassKind(v1alpha3.ContainerClassGroupVersionKind),
 		))
@@ -100,14 +103,14 @@ func (c *ClaimController) SetupWithManager(mgr ctrl.Manager) error {
 		v1alpha3.ContainerKind,
 		v1alpha3.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 		resource.ClassKind(v1alpha3.ContainerClassGroupVersionKind),
 		resource.ManagedKind(v1alpha3.ContainerGroupVersionKind),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureContainer),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureContainer),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/storage/container/claim_test.go
+++ b/pkg/controller/storage/container/claim_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/apis/storage/v1alpha1"
@@ -34,7 +35,7 @@ import (
 	"github.com/crossplaneio/stack-azure/apis/storage/v1alpha3"
 )
 
-var _ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureContainer)
+var _ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureContainer)
 
 func TestConfigureContainer(t *testing.T) {
 	type args struct {

--- a/pkg/controller/storage/container/container.go
+++ b/pkg/controller/storage/container/container.go
@@ -34,6 +34,7 @@ import (
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/logging"
 	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 
 	azure "github.com/crossplaneio/stack-azure/pkg/clients"
@@ -71,7 +72,7 @@ var (
 type Reconciler struct {
 	client.Client
 	syncdeleterMaker
-	resource.ManagedReferenceResolver
+	managed.ReferenceResolver
 }
 
 // Controller is responsible for adding the Container controller and its
@@ -82,9 +83,9 @@ type Controller struct{}
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	r := &Reconciler{
-		Client:                   mgr.GetClient(),
-		syncdeleterMaker:         &containerSyncdeleterMaker{mgr.GetClient()},
-		ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(mgr.GetClient()),
+		Client:            mgr.GetClient(),
+		syncdeleterMaker:  &containerSyncdeleterMaker{mgr.GetClient()},
+		ReferenceResolver: managed.NewAPIReferenceResolver(mgr.GetClient()),
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -112,7 +113,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	if !resource.IsConditionTrue(c.GetCondition(runtimev1alpha1.TypeReferencesResolved)) {
 		if err := r.ResolveReferences(ctx, c); err != nil {
 			condition := runtimev1alpha1.ReconcileError(err)
-			if resource.IsReferencesAccessError(err) {
+			if managed.IsReferencesAccessError(err) {
 				condition = runtimev1alpha1.ReferenceResolutionBlocked(err)
 			}
 
@@ -206,7 +207,7 @@ type syncer interface {
 	sync(context.Context) (reconcile.Result, error)
 }
 
-type creater interface {
+type creator interface {
 	create(context.Context) (reconcile.Result, error)
 }
 
@@ -257,7 +258,7 @@ func (csd *containerSyncdeleter) sync(ctx context.Context) (reconcile.Result, er
 }
 
 type createupdater interface {
-	creater
+	creator
 	updater
 }
 

--- a/pkg/controller/storage/container/container_test.go
+++ b/pkg/controller/storage/container/container_test.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 
 	"github.com/crossplaneio/stack-azure/apis/storage/v1alpha3"
@@ -253,9 +253,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
-				Client:                   tt.fields.Client,
-				syncdeleterMaker:         tt.fields.syncdeleterMaker,
-				ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(struct{ client.Client }{}),
+				Client:            tt.fields.Client,
+				syncdeleterMaker:  tt.fields.syncdeleterMaker,
+				ReferenceResolver: managed.NewAPIReferenceResolver(struct{ client.Client }{}),
 			}
 			got, err := r.Reconcile(req)
 			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This PR accomplishes the following:
- Updates to Go 1.13.5 by bumping `build` submodule
- Updates for usage of new package structure in `crossplane-runtime`
- Adds new `KubernetesTarget` reconciler

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-azure/blob/master/config/stack/manifests/app.yaml