### PR TITLE
Rehome crossplane-runtime util functions

### DIFF
--- a/pkg/clients/graph.go
+++ b/pkg/clients/graph.go
@@ -19,6 +19,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
@@ -83,7 +84,7 @@ func (c *ApplicationClient) CreateApplication(ctx context.Context, appParams App
 		return &app, err
 	}
 
-	location := util.ToLowerRemoveSpaces(appParams.Location)
+	location := strings.ToLower(strings.Replace(appParams.Location, " ", "", -1))
 	salt, err := util.GenerateHex(urlSaltDataLen)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate url salt: %+v", err)

--- a/pkg/clients/graph.go
+++ b/pkg/clients/graph.go
@@ -18,6 +18,8 @@ package azure
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -29,8 +31,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-
-	"github.com/crossplaneio/crossplane-runtime/pkg/util"
 )
 
 const (
@@ -76,6 +76,15 @@ func NewApplicationClient(c *Client) (*ApplicationClient, error) {
 	return &ApplicationClient{appClient}, nil
 }
 
+func generateHex(dataLen int) (string, error) {
+	randData := make([]byte, dataLen)
+	if _, err := rand.Read(randData); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(randData), nil
+}
+
 // CreateApplication creates a new AD application with the given parameters
 func (c *ApplicationClient) CreateApplication(ctx context.Context, appParams ApplicationParameters) (*graphrbac.Application, error) {
 	if appParams.ObjectID != "" {
@@ -85,7 +94,7 @@ func (c *ApplicationClient) CreateApplication(ctx context.Context, appParams App
 	}
 
 	location := strings.ToLower(strings.Replace(appParams.Location, " ", "", -1))
-	salt, err := util.GenerateHex(urlSaltDataLen)
+	salt, err := generateHex(urlSaltDataLen)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate url salt: %+v", err)
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
https://github.com/crossplaneio/crossplane-runtime/issues/1

Per the above issue the util package is deprecated. As best I can tell the AKS cluster controller is the only user of this retry setting, so suggest we move it to where it's used.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-azure/blob/master/config/stack/manifests/app.yaml